### PR TITLE
fix: use * instead of latest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ function supported(module) {
     throw error;
   }
 
-  if (module.version === 'latest') {
+  if (module.version === 'latest' || !module.version) {
     module.version = '*';
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,6 +105,10 @@ function supported(module) {
     throw error;
   }
 
+  if (module.version === 'latest') {
+    module.version = '*';
+  }
+
   return module;
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,6 +3,7 @@ var mod = require('../');
 
 test('module string to object', function (t) {
   t.deepEqual(mod('nodemon'), { name: 'nodemon', version: '*' }, 'supports versionless');
+  t.deepEqual(mod('nodemon@latest'), { name: 'nodemon', version: '*' }, 'switches latest to *');
   t.deepEqual(mod('nodemon@1'), { name: 'nodemon', version: '1' }, 'with version');
   t.deepEqual(mod('nodemon@1.0'), { name: 'nodemon', version: '1.0' }, 'with version');
   t.deepEqual(mod('nodemon@1.0.0'), { name: 'nodemon', version: '1.0.0' }, 'with version');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@ var mod = require('../');
 test('module string to object', function (t) {
   t.deepEqual(mod('nodemon'), { name: 'nodemon', version: '*' }, 'supports versionless');
   t.deepEqual(mod('nodemon@latest'), { name: 'nodemon', version: '*' }, 'switches latest to *');
+  t.deepEqual(mod('nodemon@'), { name: 'nodemon', version: '*' }, 'always give a version');
   t.deepEqual(mod('nodemon@1'), { name: 'nodemon', version: '1' }, 'with version');
   t.deepEqual(mod('nodemon@1.0'), { name: 'nodemon', version: '1.0' }, 'with version');
   t.deepEqual(mod('nodemon@1.0.0'), { name: 'nodemon', version: '1.0.0' }, 'with version');


### PR DESCRIPTION
- [x] Reviewed by @remy (...)

#### What's this PR do?

Uses `*` as the version in place of `latest` to be consistent with usage inside snyk/vuln repo.

#### How should this be manually tested?

Clone repo, and from the repo directory, test:

```bash
$ node . foo
$ node . foo@
$ node . foo@*
$ node . foo@latest
```

They should all yield the same result: `{ name: 'foo', version: '*' }`