### PR TITLE
feat: support version arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ Parses a string module name into an object, and tests for Snyk support.
 
 See [tests](https://github.com/Snyk/module/blob/4a1055822a33b4294bd28e3502135e1153c06a46/test/index.test.js) for examples.
 
-Note that at this time the following are not supported in Snyk:
+## Testing manually
 
-- Private npm modules
-- External modules, i.e. those loaded over http or git
+You can use this module from the terminal whilst inside the root of the repo directory:
+
+```bash
+$ node . foo@3
+{ name: "foo", version: 3 }
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,17 +5,27 @@ var debug = require('debug')('snyk:module');
 var gitHost = require('hosted-git-info');
 var validate = require('validate-npm-package-name');
 
-function moduleToObject(str) {
+/**
+ * Converts a string module name to an object
+ * @param  {String} str     Required module name (can also include @version)
+ * @param  {String} version Optional version
+ * @return {Object}         Containing .name & .version properties
+ */
+function moduleToObject(str, version) {
   if (!str) {
     throw new Error('requires string to parse into module');
   }
 
-  debug('module to object from: %s', str);
+  if (version && str.lastIndexOf('@') < 1) {
+    debug('appending version onto string');
+    str += '@' + version;
+  }
 
-  var url = looksLikeUrl(str);
-  if (url) {
+
+  var gitObject = looksLikeUrl(str);
+  if (gitObject) {
     // then the string looks like a url, let's try to parse it
-    return supported(fromUrl(url));
+    return supported(str, fromGitObject(gitObject));
   }
 
   var parts = str.split('@');
@@ -35,9 +45,7 @@ function moduleToObject(str) {
     version: parts[1],
   };
 
-  debug('parsed from string');
-
-  return supported(module);
+  return supported(str, module);
 }
 
 function looksLikeUrl(str) {
@@ -51,10 +59,10 @@ function looksLikeUrl(str) {
   return obj;
 }
 
-function fromUrl(obj) {
+function fromGitObject(obj) {
   var error = false;
 
-  debug('parsed from hosted-git-info');
+  // debug('parsed from hosted-git-info');
 
   /* istanbul ignore if */
   if (!obj.project || !obj.user) {
@@ -73,14 +81,14 @@ function fromUrl(obj) {
     module.version += '#' + obj.committish;
   }
 
-  return supported(module);
+  return module;
 }
 
 function encode(name) {
   return name[0] + encodeURIComponent(name.slice(1));
 }
 
-function supported(module) {
+function supported(str, module) {
   var error;
 
   var valid = validate(module.name);
@@ -88,6 +96,7 @@ function supported(module) {
   if (!valid.validForOldPackages) {
     error = new Error('invalid package name: ' + module.name +
       ', errors: ' + (valid.warnings || valid.errors || []).join('\n'));
+    debug('not supported %s@%s (ext)', module.name, module.version);
     throw error;
   }
 
@@ -108,6 +117,9 @@ function supported(module) {
   if (module.version === 'latest' || !module.version) {
     module.version = '*';
   }
+
+  debug('%s => { name: "%s", version: "%s" }',
+    str, module.name, module.version);
 
   return module;
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,6 +12,9 @@ test('module string to object', function (t) {
   t.deepEqual(mod('@remy/snyk-module'), { name: '@remy/snyk-module', version: '*' }, 'private packages');
   t.deepEqual(mod('jsbin/jsbin'), { name: 'jsbin', version: 'jsbin/jsbin' }, 'short github works');
 
+  t.deepEqual(mod('jsbin', 1), { name: 'jsbin', version: '1' }, 'version arg works');
+  t.deepEqual(mod('@remy/jsbin', 1), { name: '@remy/jsbin', version: '1' }, 'scoped with version arg works');
+
   [
     'a@1',
     'url',


### PR DESCRIPTION
Though by default we expect the full name and version in the first string, but this allows the logic to be removed from the vuln repo.

Also simplifies the debug output.