### PR TITLE
fix: remove npm package name validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@ module.exports.encode = encode;
 
 var debug = require('debug')('snyk:module');
 var gitHost = require('hosted-git-info');
-var validate = require('validate-npm-package-name');
 
 /**
  * Converts a string module name to an object
@@ -130,14 +129,6 @@ function supported(str, module, options) {
       throw new Error('invalid Maven package name: ' + str);
     }
     return module;
-  }
-  var valid = validate(module.name);
-
-  if (!valid.validForOldPackages) {
-    error = new Error('invalid package name: ' + module.name +
-      ', errors: ' + (valid.warnings || valid.errors || []).join('\n'));
-    debug('not supported %s@%s (ext)', module.name, module.version);
-    throw error;
   }
 
   var protocolMatch = module.version.match(/^(https?:)|(git[:+])/i);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "hosted-git-info": "^2.1.4",
-    "validate-npm-package-name": "^2.2.2"
+    "hosted-git-info": "^2.1.4"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,15 +51,6 @@ test('module string to object', function (t) {
   t.deepEqual(mod(urls[0] + '#123'), { name: 'undefsafe', version: 'remy/undefsafe#123'}, 'add hash correctly');
 
   t.throws(function () {
-    mod('/');
-  }, /invalid package name/, 'catch invalid package name');
-
-  t.throws(function () {
-    mod('  *');
-  }, /invalid package name/, 'catch invalid package name');
-
-
-  t.throws(function () {
     mod();
   }, /requires string/, 'requires args');
 
@@ -99,10 +90,10 @@ test('loose parsing', function (t) {
 
 test('vanilla urls from github', function (t) {
   var urls = [
-    'https://github.com/Snyk/module/tree/v1.6.0',
-    'https://github.com/Snyk/module',
-    'https://github.com/Snyk/module/tree/master',
-    'https://github.com/Snyk/module/commit/fc0ac92416fe330cb9d13b6cdefa007de81885ad'
+    'https://github.com/snyk/module/tree/v1.6.0',
+    'https://github.com/snyk/module',
+    'https://github.com/snyk/module/tree/master',
+    'https://github.com/snyk/module/commit/fc0ac92416fe330cb9d13b6cdefa007de81885ad'
   ];
 
   var expect = [


### PR DESCRIPTION
The purpose of this change is to allow processing of packages with names that do not allow publishing to npm, but are valid in any other sense. For example, names starting with _ or containing {