### PR TITLE
feat: support git packages as package versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ function moduleToObject(str, version, options) {
 
   var module = {
     name: parts[0],
-    version: parts[1],
+    version: parts.slice(1).join('@'),
   };
 
   return supported(str, module, options);
@@ -139,7 +139,7 @@ function supported(str, module, options) {
     if (options.loose) {
       delete module.version;
     } else {
-      error = new Error('not supported: external module: ' + toString(module));
+      debug('external module: ' + toString(module));
     }
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -63,10 +63,18 @@ test('module string to object', function (t) {
       version: 'Zolmeister/grunt-sails-linker'
     }, 'package + giturl as version works');
 
-  // privately hosted git repo not supported
-  t.throws(function () {
-    mod('ikt@git+http://ikt.pm2.io/ikt.git#master');
-  }, /not supported: external module/, 'external not supported');
+  // privately hosted git repo is supported
+  t.deepEqual(mod('ikt@git+http://ikt.pm2.io/ikt.git#master'),
+    { name: 'ikt', version: 'git+http://ikt.pm2.io/ikt.git#master' },
+    'external git repo is supported');
+
+  t.deepEqual(mod('ikt@git+ssh://git@ikt.pm2.io/ikt.git#master'),
+    { name: 'ikt', version: 'git+ssh://git@ikt.pm2.io/ikt.git#master' },
+    'external git repo with ssh is supported');
+
+  t.deepEqual(mod('@scope/ikt@git+ssh://git@ikt.pm2.io/ikt.git#master'),
+    { name: '@scope/ikt', version: 'git+ssh://git@ikt.pm2.io/ikt.git#master' },
+    'scoped package with git repo is supported');
 
   t.end();
 });


### PR DESCRIPTION
Now that we are using package-lock.json we get the full name of
the package, i.e. 'git+ssh@bitbucket.org:org-name/package.git'.

This relaxes the check and allow those package to come through.