### PR TITLE
feat: refactor the code (TS, prettier); document and rename.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,51 +1,29 @@
 {
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 6
   },
   "env": {
     "node": true,
     "es6": true
   },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+    "prettier/@typescript-eslint",
+  ],
   "rules": {
-    "array-bracket-spacing": [2, "never"],
-    "block-scoped-var": 2,
-    "brace-style": 2,
-    "camelcase": 1,
-    "comma-dangle": ["error", "always-multiline"],
-    "computed-property-spacing": [2, "never"],
-    "curly": 2,
-    "eol-last": 2,
-    "eqeqeq": [2, "smart"],
-    "guard-for-in": 2,
-    "indent": [
-      2,
-      2,
-      {
-        "SwitchCase": 1
-      }
-    ],
-    "max-depth": [1, 5],
-    "max-len": [1, 120],
-    "max-statements": [1, 100],
-    "new-cap": 0,
-    "no-caller": 2,
-    "no-else-return": 2,
-    "no-extend-native": 2,
-    "no-mixed-spaces-and-tabs": 2,
-    "no-trailing-spaces": 2,
-    "no-undef": 2,
-    "no-unused-vars": 1,
-    "no-use-before-define": [2, "nofunc"],
-    "quotes": [2, "single", "avoid-escape"],
-    "semi": [2, "always"],
-    "keyword-spacing": [2, {"before": true, "after": true}],
-    "space-before-function-paren": [
-      2,
-      {
-        "anonymous": "ignore",
-        "named": "never"
-      }
-    ],
-    "space-unary-ops": 2
-  }
+    "@typescript-eslint/explicit-function-return-type": 0,
+    "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/no-var-requires": 0,
+    "@typescript-eslint/no-use-before-define": 0,
+    "no-prototype-builtins": 0,
+    "no-var": 2,
+    "prefer-arrow-callback": 2,
+    "prefer-const": 2,
+    "require-atomic-updates": 0,
+  },
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 .nyc_output
+dist
+.eslintcache
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "arrowParens": "always",
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "htmlWhitespaceSensitivity": "ignore"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ cache:
 notifications:
   email: false
 node_js:
+  - '12'
   - '10'
   - '8'
   - '6'
-  - '4'
 install:
   - npm install
 script:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,13 @@
 # snyk/module
 
-
 [![Build Status](https://travis-ci.org/Snyk/module.svg?branch=master)](https://travis-ci.org/Snyk/module) [![Coverage Status](https://coveralls.io/repos/Snyk/module/badge.svg?branch=master&service=github)](https://coveralls.io/github/Snyk/module?branch=develop)
 
-Parses a string module name into an object, and tests for Snyk support.
+Parses a string package name (with optional version) into an object, and tests for Snyk support.
 
-See [tests](https://github.com/Snyk/module/blob/4a1055822a33b4294bd28e3502135e1153c06a46/test/index.test.js) for examples.
+This is designed to handle `npm` package names in particular (e.g. Git urls).
 
-## Testing manually
+See [tests](test/index.test.js) for examples.
 
-You can use this module from the terminal whilst inside the root of the repo directory:
+`snyk-module` is the legacy name.
 
-```bash
-$ node . foo@3
-{ name: "foo", version: 3 }
-```
+*TODO: rename the repo/package to @snyk/package-name-parser.*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snyk-module",
   "description": "Snyk module helper",
-  "main": "lib/index.js",
+  "main": "dist/lib/index.js",
   "directories": {
     "test": "test"
   },
@@ -10,16 +10,26 @@
     "url": "https://github.com/snyk/module.git"
   },
   "scripts": {
-    "lint": "eslint -c .eslintrc lib",
-    "test": "npm run lint && tap test/*.test.js -R spec --timeout=60"
+    "lint": "npm run format:check && eslint --cache '{lib,test}/**/*.{js,ts}'",
+    "test": "npm run lint && tap --node-arg=-r --node-arg=ts-node/register test/*.test.js -R spec --timeout=60",
+    "format:check": "prettier --check '{lib,test}/**/*.{js,ts}'",
+    "format": "prettier --write '{lib,test}/**/*.{js,ts}'"
   },
   "author": "Remy Sharp",
   "license": "Apache-2.0",
   "devDependencies": {
-    "eslint": "^4.0.0",
-    "tap": "^12.0.1"
+    "@typescript-eslint/eslint-plugin": "^1.13.0",
+    "@typescript-eslint/parser": "^1.13.0",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^6.0.0",
+    "prettier": "^1.18.2",
+    "tap": "^12.7.0",
+    "ts-node": "^8.3.0",
+    "typescript": "^3.5.3"
   },
   "dependencies": {
+    "@types/hosted-git-info": "^2.7.0",
+    "@types/node": "^6.14.7",
     "debug": "^3.1.0",
     "hosted-git-info": "^2.7.1"
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,26 +1,60 @@
-var test = require('tap').test;
-var mod = require('../');
+const test = require('tap').test;
+const mod = require('../lib').parsePackageString;
+mod.encode = require('../lib').encode;
 
-test('module string to object', function (t) {
-  t.deepEqual(mod('nodemon'), { name: 'nodemon', version: '*' }, 'supports versionless');
-  t.deepEqual(mod('nodemon@latest'), { name: 'nodemon', version: '*' }, 'switches latest to *');
-  t.deepEqual(mod('nodemon@'), { name: 'nodemon', version: '*' }, 'always give a version');
-  t.deepEqual(mod('nodemon@1'), { name: 'nodemon', version: '1' }, 'with version');
-  t.deepEqual(mod('nodemon@1.0'), { name: 'nodemon', version: '1.0' }, 'with version');
-  t.deepEqual(mod('nodemon@1.0.0'), { name: 'nodemon', version: '1.0.0' }, 'with version');
+test('module string to object', (t) => {
+  t.deepEqual(
+    mod('nodemon'),
+    { name: 'nodemon', version: '*' },
+    'supports versionless'
+  );
+  t.deepEqual(
+    mod('nodemon@latest'),
+    { name: 'nodemon', version: '*' },
+    'switches latest to *'
+  );
+  t.deepEqual(
+    mod('nodemon@'),
+    { name: 'nodemon', version: '*' },
+    'always give a version'
+  );
+  t.deepEqual(
+    mod('nodemon@1'),
+    { name: 'nodemon', version: '1' },
+    'with version'
+  );
+  t.deepEqual(
+    mod('nodemon@1.0'),
+    { name: 'nodemon', version: '1.0' },
+    'with version'
+  );
+  t.deepEqual(
+    mod('nodemon@1.0.0'),
+    { name: 'nodemon', version: '1.0.0' },
+    'with version'
+  );
 
-  t.deepEqual(mod('@remy/snyk-module'), { name: '@remy/snyk-module', version: '*' }, 'private packages');
-  t.deepEqual(mod('jsbin', 1), { name: 'jsbin', version: '1' }, 'version arg works');
-  t.deepEqual(mod('@remy/jsbin', 1), { name: '@remy/jsbin', version: '1' }, 'scoped with version arg works');
+  t.deepEqual(
+    mod('@remy/snyk-module'),
+    { name: '@remy/snyk-module', version: '*' },
+    'private packages'
+  );
+  t.deepEqual(
+    mod('jsbin', 1),
+    { name: 'jsbin', version: '1' },
+    'version arg works'
+  );
+  t.deepEqual(
+    mod('@remy/jsbin', 1),
+    { name: '@remy/jsbin', version: '1' },
+    'scoped with version arg works'
+  );
 
-  [
-    'a@1',
-    'url',
-  ].forEach(function (str) {
+  ['a@1', 'url'].forEach((str) => {
     t.ok(mod(str), str + ' parsed ok');
   });
 
-  var urls = [
+  let urls = [
     'https://github.com/remy/undefsafe',
     'https://github.com/remy/undefsafe/',
     'https://github.com/remy/undefsafe.git',
@@ -29,7 +63,7 @@ test('module string to object', function (t) {
     'remy/undefsafe',
   ];
 
-  urls = urls.reduce(function (acc, curr) {
+  urls = urls.reduce((acc, curr) => {
     acc.push(curr);
     if (curr.indexOf('@') === -1) {
       acc.push('undefsafe@' + curr);
@@ -37,125 +71,169 @@ test('module string to object', function (t) {
     return acc;
   }, []);
 
-  var expect = {
+  const expect = {
     name: 'undefsafe',
     version: 'remy/undefsafe',
   };
 
-  urls.forEach(function (url) {
+  urls.forEach((url) => {
     t.deepEqual(mod(url), expect, url + ' works');
   });
 
-  t.deepEqual(mod('jsbin/jsbin'), { name: 'jsbin', version: 'jsbin/jsbin' }, 'short github works');
+  t.deepEqual(
+    mod('jsbin/jsbin'),
+    { name: 'jsbin', version: 'jsbin/jsbin' },
+    'short github works'
+  );
 
-  t.deepEqual(mod(urls[0] + '#123'), { name: 'undefsafe', version: 'remy/undefsafe#123'}, 'add hash correctly');
+  t.deepEqual(
+    mod(urls[0] + '#123'),
+    { name: 'undefsafe', version: 'remy/undefsafe#123' },
+    'add hash correctly'
+  );
 
-  t.throws(function () {
-    mod();
-  }, /requires string/, 'requires args');
-
+  t.throws(
+    () => {
+      mod();
+    },
+    /requires string/,
+    'requires args'
+  );
 
   // pkg names
   t.deepEqual(
-    mod('grunt-sails-linker@git://github.com/Zolmeister/grunt-sails-linker.git'),
+    mod(
+      'grunt-sails-linker@git://github.com/Zolmeister/grunt-sails-linker.git'
+    ),
     {
       name: 'grunt-sails-linker',
-      version: 'Zolmeister/grunt-sails-linker'
-    }, 'package + giturl as version works');
+      version: 'Zolmeister/grunt-sails-linker',
+    },
+    'package + giturl as version works'
+  );
 
   // privately hosted git repo is supported
-  t.deepEqual(mod('ikt@git+http://ikt.pm2.io/ikt.git#master'),
+  t.deepEqual(
+    mod('ikt@git+http://ikt.pm2.io/ikt.git#master'),
     { name: 'ikt', version: 'git+http://ikt.pm2.io/ikt.git#master' },
-    'external git repo is supported');
-
-  t.deepEqual(mod('ikt@git+ssh://git@ikt.pm2.io/ikt.git#master'),
-    { name: 'ikt', version: 'git+ssh://git@ikt.pm2.io/ikt.git#master' },
-    'external git repo with ssh is supported');
-
-  t.deepEqual(mod('@scope/ikt@git+ssh://git@ikt.pm2.io/ikt.git#master'),
-    { name: '@scope/ikt', version: 'git+ssh://git@ikt.pm2.io/ikt.git#master' },
-    'scoped package with git repo is supported');
-
-  t.end();
-});
-
-test('loose parsing', function (t) {
-  var opts = { loose: true };
+    'external git repo is supported'
+  );
 
   t.deepEqual(
-    mod('grunt-sails-linker@git://github.com/Zolmeister/grunt-sails-linker.git', opts),
-    {
-      name: 'grunt-sails-linker',
-      version: 'Zolmeister/grunt-sails-linker'
-    }, 'package + giturl as version works');
+    mod('ikt@git+ssh://git@ikt.pm2.io/ikt.git#master'),
+    { name: 'ikt', version: 'git+ssh://git@ikt.pm2.io/ikt.git#master' },
+    'external git repo with ssh is supported'
+  );
 
-  // privately hosted git repo not supported
-  t.deepEqual(mod('ikt@git+http://ikt.pm2.io/ikt.git#master', opts),
-    { name: 'ikt', version: '*' }, 'loose allows non-supported parsing');
+  t.deepEqual(
+    mod('@scope/ikt@git+ssh://git@ikt.pm2.io/ikt.git#master'),
+    { name: '@scope/ikt', version: 'git+ssh://git@ikt.pm2.io/ikt.git#master' },
+    'scoped package with git repo is supported'
+  );
 
   t.end();
 });
 
-test('vanilla urls from github', function (t) {
-  var urls = [
+test('loose parsing', (t) => {
+  const opts = { loose: true };
+
+  t.deepEqual(
+    mod(
+      'grunt-sails-linker@git://github.com/Zolmeister/grunt-sails-linker.git',
+      opts
+    ),
+    {
+      name: 'grunt-sails-linker',
+      version: 'Zolmeister/grunt-sails-linker',
+    },
+    'package + giturl as version works'
+  );
+
+  // privately hosted git repo not supported
+  t.deepEqual(
+    mod('ikt@git+http://ikt.pm2.io/ikt.git#master', opts),
+    { name: 'ikt', version: '*' },
+    'loose allows non-supported parsing'
+  );
+
+  t.end();
+});
+
+test('vanilla urls from github', (t) => {
+  const urls = [
     'https://github.com/snyk/module/tree/v1.6.0',
     'https://github.com/snyk/module',
     'https://github.com/snyk/module/tree/master',
-    'https://github.com/snyk/module/commit/fc0ac92416fe330cb9d13b6cdefa007de81885ad'
+    'https://github.com/snyk/module/commit/fc0ac92416fe330cb9d13b6cdefa007de81885ad',
   ];
 
-  var expect = [
+  const expect = [
     { name: 'module', version: 'snyk/module#v1.6.0' },
     { name: 'module', version: 'snyk/module' },
     { name: 'module', version: 'snyk/module#master' },
-    { name: 'module', version: 'snyk/module#fc0ac92416fe330cb9d13b6cdefa007de81885ad' },
-  ]
+    {
+      name: 'module',
+      version: 'snyk/module#fc0ac92416fe330cb9d13b6cdefa007de81885ad',
+    },
+  ];
 
-  urls.forEach(function (url, i) {
+  urls.forEach((url, i) => {
     t.deepEqual(mod(url), expect[i], url + ' works');
   });
 
   t.end();
 });
 
-test('encoding', function (t) {
+test('encoding', (t) => {
   t.equal(mod.encode('snyk'), 'snyk', 'vanilla strings unaffected');
   t.equal(mod.encode('@snyk/config'), '@snyk%2Fconfig', 'slash is escaped');
   t.end();
 });
 
-test('Maven modules', function(t) {
-  var groupId = 'org.apache.httpcomponents';
-  var artifactId = 'httpcomponents-core';
-  var packageName = groupId + ':' + artifactId;
+test('Maven modules', (t) => {
+  const groupId = 'org.apache.httpcomponents';
+  const artifactId = 'httpcomponents-core';
+  const packageName = groupId + ':' + artifactId;
 
   t.equal(mod.encode(packageName), groupId + '%3A' + artifactId);
 
-  t.deepEqual(mod(packageName, {packageManager: 'maven'}),
-    {name: packageName, version: '*'});
+  t.deepEqual(mod(packageName, { packageManager: 'maven' }), {
+    name: packageName,
+    version: '*',
+  });
 
-  t.deepEqual(mod(packageName, '3.4.5', {packageManager: 'maven'}),
-    {name: packageName, version: '3.4.5'});
+  t.deepEqual(mod(packageName, '3.4.5', { packageManager: 'maven' }), {
+    name: packageName,
+    version: '3.4.5',
+  });
 
-  t.deepEqual(mod(packageName, '3.4.5-SNAPSHOT', {packageManager: 'maven'}),
-    {name: packageName, version: '3.4.5-SNAPSHOT'});
+  t.deepEqual(mod(packageName, '3.4.5-SNAPSHOT', { packageManager: 'maven' }), {
+    name: packageName,
+    version: '3.4.5-SNAPSHOT',
+  });
 
-  t.deepEqual(mod(packageName + '@3.4.5', {packageManager: 'maven'}),
-    {name: packageName, version: '3.4.5'});
+  t.deepEqual(mod(packageName + '@3.4.5', { packageManager: 'maven' }), {
+    name: packageName,
+    version: '3.4.5',
+  });
 
   try {
-    mod(groupId, {packageManager: 'maven'});
-  } catch(e) {
+    mod(groupId, { packageManager: 'maven' });
+  } catch (e) {
     t.equal(e.message, 'invalid Maven package name: ' + groupId);
   }
 
   try {
     mod(packageName);
-  } catch(e) {
-    t.equal(e.message,
+  } catch (e) {
+    t.equal(
+      e.message,
       'invalid package name: ' +
-      groupId + ':' + artifactId +
-      ', errors: name can only contain URL-friendly characters');
+        groupId +
+        ':' +
+        artifactId +
+        ', errors: name can only contain URL-friendly characters'
+    );
   }
 
   t.end();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+      "outDir": "./dist",
+      "pretty": true,
+      "target": "es2015",
+      "lib": [
+        "es2015",
+      ],
+      "module": "commonjs",
+      "allowJs": false,
+      "sourceMap": true,
+      "strict": true,
+      "declaration": true,
+      "importHelpers": true,
+  },
+  "include": [
+      "./lib/**/*"
+  ]
+}


### PR DESCRIPTION
BREAKING CHANGE: replaced main-function-as-export with default and named exports.
All the client should change from `moduleToObect = require('snyk-module')`
to one of:
* `import { parsePackageString } from 'snyk-module'` (and rename all usages)
* `import moduleToObject from 'snyk-module'`
* `moduleToObect = require('snyk-module').default`