### PR TITLE
fix: build js before publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .eslintcache
 package-lock.json
+dist/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "snyk-module",
   "description": "Snyk module helper",
   "main": "dist/lib/index.js",
+  "types": "dist/lib/index.d.ts",
   "directories": {
     "test": "test"
   },
@@ -10,10 +11,12 @@
     "url": "https://github.com/snyk/module.git"
   },
   "scripts": {
+    "build": "tsc",
     "lint": "npm run format:check && eslint --cache '{lib,test}/**/*.{js,ts}'",
     "test": "npm run lint && tap --node-arg=-r --node-arg=ts-node/register test/*.test.js -R spec --timeout=60",
     "format:check": "prettier --check '{lib,test}/**/*.{js,ts}'",
-    "format": "prettier --write '{lib,test}/**/*.{js,ts}'"
+    "format": "prettier --write '{lib,test}/**/*.{js,ts}'",
+    "prepare": "npm run build"
   },
   "author": "Remy Sharp",
   "license": "Apache-2.0",


### PR DESCRIPTION
Currently there is no JS code in the 'dist/' folder on npm, so
the 'main' line does nothing, and instead you cannot load the
package.