### PR TITLE
fix: main path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "snyk-module",
   "description": "Snyk module helper",
-  "main": "dist/lib/index.js",
-  "types": "dist/lib/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
`tsc` is doing its helpful dir stripping feature again,
so this path is still wrong.