### PR TITLE
feat: fast-path the common case

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -36,6 +36,16 @@ export function parsePackageString(
 
   let str = nameAndMaybeVersion;
 
+  // first, try the common case; there's no version, and it's a normal package name
+  if (!version) {
+    // foo, foo-bar, @foo/bar, com.example:test
+    // none of these can be URLs, or versions
+    const fastPath = /^(?:(?:[a-z-]+)|(?:@[a-z-]+\/[a-z-]+)|(?:[a-z-]+\.[.a-z-]+:[a-z-]+))$/;
+    if (fastPath.test(str)) {
+      return supported(str, { name: str, version: '*' }, options);
+    }
+  }
+
   if (version && str.lastIndexOf('@') < 1) {
     debug('appending version onto string');
     str += '@' + version;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
+    "benny": "^3.6.14",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^6.0.0",
     "prettier": "^1.18.2",

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,0 +1,25 @@
+const b = require('benny');
+const { parsePackageString } = require('../dist/index');
+
+b.suite(
+  'parse',
+
+  b.add('parse maven', () => {
+    parsePackageString('org.apache.httpcomponents:httpcomponents-core');
+  }),
+
+  b.add('parse namespace', () => {
+    parsePackageString('@snyk/module');
+  }),
+
+  b.add('parse regular', () => {
+    parsePackageString('modular-module');
+  }),
+
+  b.add('parse with version (slow path)', () => {
+    parsePackageString('@snyk/module', '5');
+  }),
+
+  b.cycle(),
+  b.complete()
+);


### PR DESCRIPTION
This function is called *everywhere*, but mostly with boring arguments.

We end up calling `hosted-git-info` to decide if something is a url, even if it could not possibly be a URL, and it is slow.

Instead, attempt to quickly determine if something is the standard package name, and, if it is, just return it directly. This is done by a single regex.

This is a *16x speedup* in microbenchmarks.

The benchmark is not run as a test.