### PR TITLE
feat: @types is not a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "author": "Remy Sharp",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/hosted-git-info": "^3.0.0",
+    "@types/node": "^8.10.61",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",
     "benny": "^3.6.14",
@@ -32,8 +34,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@types/hosted-git-info": "^3.0.0",
-    "@types/node": "^8.10.60",
     "debug": "^4.1.1",
     "hosted-git-info": "^3.0.4"
   }


### PR DESCRIPTION
#### What does this PR do?

`@types` packages are only needed at compile time. `typescript` is a `devDependency`, so I'm reasonably sure we're not compiling with only prod deps installed, so this can definitely be a `devDependency`.

Aiming to reduce bundle size for `snyk/snyk`.