### PR TITLE
feat: upgrade hosted-git-info to 4

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -88,7 +88,7 @@ export function parsePackageString(
 }
 
 // git host from URL
-function looksLikeUrl(str: string): gitHost {
+function looksLikeUrl(str: string): gitHost | undefined {
   if (str.slice(-1) === '/') {
     // strip the trailing slash since we can't parse it properly anyway
     str = str.slice(0, -1);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "hosted-git-info": "^3.0.4"
+    "hosted-git-info": "^4.0.2"
   }
 }


### PR DESCRIPTION
New `hosted-git-info` claims to have better performance, which is relevant to us here.

The "official" changelog for the major version change is ["we rewrote it from scratch, it should be the same, lol!"](https://github.com/npm/hosted-git-info/issues/82#issuecomment-796804092). It passes our tests, at least, and our usage is pretty light.