### PR TITLE
fix: ensure all debug logs are directed to stderr

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,8 @@
 const debug = require('debug')('snyk:module');
 import * as gitHost from 'hosted-git-info';
 
+debug.log = console.error.bind(console);
+
 interface Package {
   name: string;
   version: string;


### PR DESCRIPTION
This pull request resolves an issue where the [debug library](https://github.com/debug-js/debug) incorrectly writes log messages to `stdout` instead of `stderr`.

The fix overrides the `log` property to ensure all debug messages are consistently directed to `stderr`.
